### PR TITLE
Hotfix: 라우팅 오류

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,5 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           script: |
             cd study-mbti
-            echo "{{ secrets.BE_DOT_ENV }}" > ./.env
+            echo "${{ secrets.BE_DOT_ENV }}" > ./.env
             ./deploy.sh

--- a/src/components/progress/index.ts
+++ b/src/components/progress/index.ts
@@ -22,7 +22,7 @@ export default class Progress extends Component {
   routeToResult = (answerSheet: string[]) => {
     setTimeout(() => {
       store.dispatch(setResultAction(answerSheet));
-    }, 2000);
+    }, 1000);
   };
 
   createMarkingElement = (page: number, answerNumber: number): string => {
@@ -38,7 +38,7 @@ export default class Progress extends Component {
   template(): string {
     const test = store.getState('test');
     const { currentPage, answerSheet } = test as Test;
-    if (currentPage >= 11) this.routeToResult(answerSheet as string[]);
+    if (currentPage >= 12) this.routeToResult(answerSheet as string[]);
     return `
         <div class="omr-header">
           <button class="back-btn"><strong><</strong> 뒤로</button>

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -43,3 +43,10 @@ export const setPageAction = (
     payload: { currentPage, selectOption },
   };
 };
+
+export const setTestInit = () => {
+  return {
+    type: 'SET_TEST_INIT',
+    payload: {},
+  };
+};

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -5,7 +5,11 @@ export const reducer: any = (state: any, action: any) => {
 
   switch (action.type) {
     case 'SET_ROUTE':
-      return { ...state, route: action.payload };
+      return {
+        ...state,
+        route: action.payload,
+        test: { currentPage: 0, answerSheet: new Array(12).fill(null) },
+      };
 
     case 'SET_PAGE':
       const { currentPage, selectOption } = action.payload;

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -15,6 +15,12 @@ export const reducer: any = (state: any, action: any) => {
         : (answerSheet[currentPage - 1] = selectOption);
       return { ...state, test: { currentPage, answerSheet } };
 
+    case 'SET_TEST_INIT':
+      return {
+        ...state,
+        test: { currentPage: 0, answerSheet: new Array(12).fill(null) },
+      };
+
     default:
       return state;
   }

--- a/src/pages/test/index.ts
+++ b/src/pages/test/index.ts
@@ -14,7 +14,6 @@ let currentPage = 0;
 export default class Test extends Component {
   initState(): NoKidsObject {
     currentPage = 0;
-    setTestInit();
     return {};
   }
 
@@ -48,6 +47,7 @@ export default class Test extends Component {
     const handleLoadingOn = (): void => {
       const $testLoading = $(this.$target, '.test-loading');
       $testLoading.style.display = 'block';
+      setTestInit();
     };
 
     const answerHandler = (e: MouseEvent) => {

--- a/src/pages/test/index.ts
+++ b/src/pages/test/index.ts
@@ -55,13 +55,14 @@ export default class Test extends Component {
       if (target.classList.contains('answer-btn')) {
         const type = target.dataset.type;
         if (!type) throw new Error("Can't get an data-type in Option Button");
-
         if (currentPage >= 11) {
           handleLoadingOn();
         } else {
-          store.dispatch(setPageAction(++currentPage, type));
-          $content.style.transform = `translateX(-${8.3333 * currentPage}%)`;
+          $content.style.transform = `translateX(-${
+            8.3333 * (currentPage + 1)
+          }%)`;
         }
+        store.dispatch(setPageAction(++currentPage, type));
       }
     };
 

--- a/src/pages/test/index.ts
+++ b/src/pages/test/index.ts
@@ -2,7 +2,7 @@ import Component from '@core/component';
 import './style.scss';
 import { $ } from '@util/query-selector';
 import { store } from '@core/store';
-import { setRouteAction, setResultAction, setPageAction } from '@core/action';
+import { setRouteAction, setTestInit, setPageAction } from '@core/action';
 import loadingImg from '@assets/images/temp-loading.png';
 
 import Content from '@components/content';
@@ -14,6 +14,7 @@ let currentPage = 0;
 export default class Test extends Component {
   initState(): NoKidsObject {
     currentPage = 0;
+    setTestInit();
     return {};
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,8 @@ module.exports = {
   devtool: DEVTOOL,
   devServer: {
     static: './dist',
+    historyApiFallback: true,
+    hot: true,
   },
   module: {
     rules: [


### PR DESCRIPTION
- currentPage 컴포넌트와 store 에 저장된 값이 차이가 나는 문제를 해결했습니다.
- CI/CD yml 스크립트에서 오타로 인하여 dotenv 값이 제대로 들어가지 않는 문제를 해결했습니다.
- webpack devserver 에서 historyApiFallback: true 설정을 적용하여 라우팅 테스트를 진행했고, 뒤로가기 이벤트 발생 시, store에 저장된 값이 초기화되지 않아서 생기는 오류를 수정했습니다.